### PR TITLE
Allow admin negative transactions

### DIFF
--- a/transaction_rules.h
+++ b/transaction_rules.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace transactions {
+
+constexpr int kAdminBalanceLimit = 999999999;
+
+inline bool can_transfer_amount(int sender_balance, int amount, bool sender_is_admin) {
+    if (!sender_is_admin && amount < 0) {
+        return false;
+    }
+    int effective_sender_balance = sender_is_admin ? kAdminBalanceLimit : sender_balance;
+    return effective_sender_balance >= amount;
+}
+
+} // namespace transactions

--- a/transactions.cc
+++ b/transactions.cc
@@ -70,11 +70,10 @@ namespace transactions {
         if(transaction == nullptr) {
             return TransactionStatus::WrongId;
         }
+        int amount = std::stoi(transaction->amount);
         int balance = get_balance(transaction->sender, pool_ptr);
-        if (auth::is_rights_by_username(transaction->sender, pool_ptr)) {
-            balance = 999999999;
-        }
-        if (balance < std::stoi(transaction->amount) || (get_balance(transaction->receiver, pool_ptr) + std::stoi(transaction->amount) < 0 && std::stoi(transaction->amount) < 0)) {
+        bool sender_is_admin = auth::is_rights_by_username(transaction->sender, pool_ptr);
+        if (!can_transfer_amount(balance, amount, sender_is_admin)) {
             return TransactionStatus::NoMoney;
         }
 
@@ -159,12 +158,11 @@ namespace transactions {
 
     std::pair<TransactionStatus, std::string> prepare_transaction(std::string sender, std::string reciver, int ammount, std::shared_ptr<cp::ConnectionsManager> pool_ptr) {
         int balance = get_balance(sender, pool_ptr);
-        if (auth::is_rights_by_username(sender, pool_ptr)) {
-            balance = 999999999;
-        } else if(ammount < 0) {
+        bool sender_is_admin = auth::is_rights_by_username(sender, pool_ptr);
+        if (!sender_is_admin && ammount < 0) {
             return {TransactionStatus::NegativeNumber, ""};
         } 
-        if (balance < ammount || (get_balance(reciver, pool_ptr) + ammount < 0 && ammount < 0)) {
+        if (!can_transfer_amount(balance, ammount, sender_is_admin)) {
             return {TransactionStatus::NoMoney, ""};
         }
         std::string tr_id = to_string(

--- a/transactions.h
+++ b/transactions.h
@@ -15,6 +15,7 @@
 #include "../basic/auth.h"
 #include "../basic/url_parser.h"
 #include "../basic/comment.h"
+#include "transaction_rules.h"
 #include <vector>
 #include <cstdlib>
 


### PR DESCRIPTION
## Summary
- allow admin senders to prepare and send negative transactions
- keep negative transactions blocked for non-admin senders
- share the transaction amount rule between prepare and send checks

## Verification
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q -p no:cacheprovider test/test_transaction_rules.py
- cmake --build . --target server_starter