### PR TITLE
fix: accept auth session cookie for market endpoints

### DIFF
--- a/DOM.cc
+++ b/DOM.cc
@@ -133,11 +133,8 @@ namespace actives::deals::server {
                 return req->create_response(restinio::status_bad_request())
                     .done();
             }
-            std::string token;
-            try {
-                token = req -> header().get_field("Bearer");
-            } catch (const std::exception& e) {
-                logger_ptr->info([]{return "can't get token";});
+            std::string token = security::bearer_or_cookie_token(req->header());
+            if(token.empty()) {
                 return req->create_response(restinio::status_unauthorized()).done();
             }
 
@@ -180,11 +177,8 @@ namespace actives::deals::server {
                 return req->create_response(restinio::status_bad_request())
                 .done();
             }
-            std::string token;
-            try {
-                token = req -> header().get_field("Bearer");
-            } catch (const std::exception& e) {
-                logger_ptr->info([]{return "can't get token";});
+            std::string token = security::bearer_or_cookie_token(req->header());
+            if(token.empty()) {
                 return req->create_response(restinio::status_unauthorized()).done();
             }
 
@@ -206,12 +200,9 @@ namespace actives::deals::server {
     void users_bids(std::unique_ptr<restinio::router::express_router_t<>>& router, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr, std::shared_ptr<actives::deals::DOM> dom_ptr) {
         router.get()->http_get("/deals/users_bids", [pool_ptr, logger_ptr, dom_ptr](auto req, auto) {
             logger_ptr->trace([]{return "called /deals/users_bids";});
-            std::string token;
-            try {
-                token = req -> header().get_field("Bearer");
-            } catch (const std::exception& e) {
-                return req->create_response(restinio::status_unauthorized())
-                .done();
+            std::string token = security::bearer_or_cookie_token(req->header());
+            if(token.empty()) {
+                return req->create_response(restinio::status_unauthorized()).done();
             }
             if (token.empty()) {
                 return req->create_response(restinio::status_unauthorized())

--- a/actives.cc
+++ b/actives.cc
@@ -227,12 +227,9 @@ namespace actives::server {
     void user_actives(std::unique_ptr<restinio::router::express_router_t<>>& router, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr) {
         router.get()->http_get("/actives/user_actives", [pool_ptr, logger_ptr](auto req, auto) {
             logger_ptr->trace([]{return "called /actives/user_actives";});
-            std::string token;
-            try {
-                token = req->header().get_field("Bearer");
-            } catch (const std::exception& e) {
-                return req->create_response(restinio::status_unauthorized())
-                .done();
+            std::string token = security::bearer_or_cookie_token(req->header());
+            if(token.empty()) {
+                return req->create_response(restinio::status_unauthorized()).done();
             } if (token.empty()) {
                 logger_ptr->info([]{return "token is empty";});
                 return req->create_response(restinio::status_unauthorized()).done();
@@ -250,12 +247,9 @@ namespace actives::server {
     void user_history(std::unique_ptr<restinio::router::express_router_t<>>& router, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr) {
         router.get()->http_get("/actives/user_history", [pool_ptr, logger_ptr](auto req, auto) {
             logger_ptr->trace([]{return "called /actives/user_history";});
-            std::string token;
-            try {
-                token = req->header().get_field("Bearer");
-            } catch (const std::exception& e) {
-                return req->create_response(restinio::status_unauthorized())
-                .done();
+            std::string token = security::bearer_or_cookie_token(req->header());
+            if(token.empty()) {
+                return req->create_response(restinio::status_unauthorized()).done();
             } if (token.empty()) {
                 logger_ptr->info([]{return "token is empty";});
                 return req->create_response(restinio::status_unauthorized()).done();

--- a/transactions.cc
+++ b/transactions.cc
@@ -194,12 +194,9 @@ namespace transactions::server {
             rapidjson::Document new_body;
             new_body.Parse(req->body().c_str());
 
-            std::string token;
-            try {
-                token = req -> header().get_field("Bearer");
-            } catch (const std::exception& e) {
-                return req->create_response(restinio::status_unauthorized())
-                .done();
+            std::string token = security::bearer_or_cookie_token(req->header());
+            if(token.empty()) {
+                return req->create_response(restinio::status_unauthorized()).done();
             }
 
             if (token.empty()) {
@@ -271,11 +268,8 @@ namespace transactions::server {
             rapidjson::Document new_body;
             new_body.Parse(req->body().c_str());
 
-            std::string token;
-            try {
-                token = req -> header().get_field("Bearer");
-            } catch (const std::exception& e) {
-                logger_ptr->info([]{return "can't get token";});
+            std::string token = security::bearer_or_cookie_token(req->header());
+            if(token.empty()) {
                 return req->create_response(restinio::status_unauthorized()).done();
             }
 
@@ -328,13 +322,9 @@ namespace transactions::server {
     void get_balance(std::unique_ptr<restinio::router::express_router_t<>>& router, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr) {
         router.get()->http_get("/transactions/balance", [pool_ptr, logger_ptr](auto req, auto) {
             logger_ptr->trace([]{return "called /transactions/balance";});
-            std::string token;
-
-            try {
-                token = req -> header().get_field("Bearer");
-            } catch (const std::exception& e) {
-                return req->create_response(restinio::status_unauthorized())
-                .done();
+            std::string token = security::bearer_or_cookie_token(req->header());
+            if(token.empty()) {
+                return req->create_response(restinio::status_unauthorized()).done();
             }
 
             if (token.empty()) {
@@ -359,12 +349,9 @@ namespace transactions::server {
     void get_transactions(std::unique_ptr<restinio::router::express_router_t<>>& router, std::shared_ptr<cp::ConnectionsManager> pool_ptr, std::shared_ptr<restinio::shared_ostream_logger_t> logger_ptr) {
         router.get()->http_get("/transactions/my", [pool_ptr, logger_ptr](auto req, auto) {
             logger_ptr->trace([]{return "called /transactions/my";});
-            std::string token;
-            try {
-                token = req -> header().get_field("Bearer");
-            } catch (const std::exception& e) {
-                return req->create_response(restinio::status_unauthorized())
-                .done();
+            std::string token = security::bearer_or_cookie_token(req->header());
+            if(token.empty()) {
+                return req->create_response(restinio::status_unauthorized()).done();
             }
 
             if (token.empty()) {


### PR DESCRIPTION
## Summary
- Make market/transaction endpoints accept the same auth source as the rest of the portal: legacy `Bearer` header or HttpOnly `AuthSession` cookie.
- Preserve unauthorized responses when no token is present.

## Why
After the session-cookie rollout, browser requests no longer send a custom `Bearer` header. Endpoints that still read only `req->header().get_field("Bearer")` fail for logged-in users.

## Test Plan
- Parent PR regression: `test_backend_routes_use_cookie_aware_auth_helper_instead_of_legacy_bearer_only`
- `python3 -m pytest -q test/test_security_vulnerabilities.py::test_backend_routes_use_cookie_aware_auth_helper_instead_of_legacy_bearer_only test/test_security_vulnerabilities.py::test_social_like_dislike_accept_http_only_auth_session_cookie test/test_security_vulnerabilities.py::test_social_news_saved_and_titles_accept_http_only_auth_session_cookie`
